### PR TITLE
Change event card title to map name

### DIFF
--- a/web/components/event-card.vue
+++ b/web/components/event-card.vue
@@ -1,6 +1,6 @@
 <template>
   <card
-    :title="$attrs.title || (mode != undefined ? $t('mode.' + mode) : undefined)"
+    :title="$attrs.title || map || (mode != undefined ? $t('mode.' + mode) : undefined)"
     :title-link="mode != undefined ? localePath(`/tier-list/mode/${camelToKebab(mode)}`) : undefined"
     :subtitle="id != undefined ? (id != 0 ? $t('map.' + id) : map) : undefined"
     :subtitle-link="map != undefined ? localePath(`/tier-list/mode/${camelToKebab(mode)}/map/${slugify(map)}`) : undefined"


### PR DESCRIPTION
In order to readily tell the event cards apart, the card title should be the map's name, instead of the subtitle (which is also hidden it seems?)

![CleanShot 2021-09-22 at 20 41 29](https://user-images.githubusercontent.com/1146921/134443442-f3d40ea8-675c-406c-b5fe-34cb633bac90.png)

![CleanShot 2021-09-22 at 20 41 42](https://user-images.githubusercontent.com/1146921/134443448-06f4bb8e-f765-4fba-bdf5-c559d80d5200.png)


