### PR TITLE
Enh: card titleLink mobile clickability

### DIFF
--- a/klicker/components/c-slicer.vue
+++ b/klicker/components/c-slicer.vue
@@ -2,13 +2,13 @@
   <!-- increase z-index so that <b-fake-select> overlaps the following cards -->
   <b-card
     class="relative z-10"
-    v-bind="{ ...card, title }"
+    v-bind="{ ...card, title, titleLink: toggleFilters }"
   >
     <button
       slot="preview"
       :selected="showFilters"
       class="md:hidden w-10"
-      @click="showFilters = !showFilters"
+      @click="toggleFilters"
     >
       <font-awesome-icon
         :icon="faFilter"
@@ -229,6 +229,11 @@ export default defineComponent({
       faFilter,
       specs,
       translate,
+    }
+  },
+  methods: {
+    toggleFilters() {
+      this.showFilters = !this.showFilters;
     }
   }
 })

--- a/klicker/components/ui/b-card.vue
+++ b/klicker/components/ui/b-card.vue
@@ -74,7 +74,7 @@
             }"
           >
             <router-link
-              v-if="titleLink != undefined || link != undefined"
+              v-if="typeof titleLink === 'string' || typeof link === 'string'"
               v-slot="{ href, navigate }"
               :to="titleLink || link"
               class="contents"
@@ -82,6 +82,9 @@
             >
               <a :href="href" @click.stop="navigate">{{ title }}</a>
             </router-link>
+            <button v-else-if="typeof titleLink === 'function'" @click="titleLink">
+              {{ title }}
+            </button>
             <template v-else>
               {{ title }}
             </template>
@@ -217,7 +220,7 @@ export default defineComponent({
       type: String,
     },
     titleLink: {
-      type: String,
+      type: [String, Function]
     },
     subtitle: {
       type: String,


### PR DESCRIPTION
Improves mobile UX by **allowing card to be toggled by clicking the title** _or_ the (small) filter icon.
'Overloads' `titleLink` prop to also accept a raw callback in lieu of a `<RouterLink>` string.

![ss 2022-03-21 at 17 43 06](https://user-images.githubusercontent.com/1146921/159375106-da9103d5-b01d-4487-93b7-86c954522e53.gif)

