### PR TITLE
Fix: map name (lang) fallback

### DIFF
--- a/web/components/event-card.vue
+++ b/web/components/event-card.vue
@@ -3,7 +3,7 @@
     :title="$attrs.title || (mode != undefined ? $t('mode.' + mode) : undefined)"
     :link="mapLink || modeLink"
     :title-link="modeLink"
-    :subtitle="id != undefined ? (id != 0 ? $t('map.' + id) : map) : undefined"
+    :subtitle="$te(`map.${id}`) && $t(`map.${id}`) || map || undefined"
     :subtitle-link="mapLink"
     :background="background"
     :color="mode != undefined ? 'bg-color-' + mode.toLowerCase() : undefined"

--- a/web/components/klicker/s-mode-map.vue
+++ b/web/components/klicker/s-mode-map.vue
@@ -26,7 +26,7 @@
         v-for="map in maps"
         :key="map.battle_event_map"
         :value="map.battle_event_map"
-      >{{ map.battle_event_id != 0 ? $t('map.' + map.battle_event_id) : map.battle_event_map }}</option>
+      >{{ $te(`map.${map.battle_event_id}`) && $t(`map.${map.battle_event_id}`) || map.battle_event_map }}</option>
     </b-select>
   </div>
 </template>

--- a/web/components/map-img.vue
+++ b/web/components/map-img.vue
@@ -2,7 +2,7 @@
   <media-img
     slot="preview"
     :path="id != 0 ? `/maps/${id}` : `/maps/competition-winners/${map.replace('Competition Winner ', '')}`"
-    :alt="$t('map.' + id)"
+    :alt="$te(`map.${id}`) ? $t(`map.${id}`): map"
     :clazz="clazz"
     size="512"
   ></media-img>

--- a/web/components/map/map-breadcrumbs.vue
+++ b/web/components/map/map-breadcrumbs.vue
@@ -100,7 +100,7 @@
         xs
         dark
       >
-        <span itemprop="name">{{ id != 0 ? $t('map.' + id) : map }}</span>
+        <span itemprop="name">{{ $te(`map.${id}`) && $t(`map.${id}`) || map }}</span>
       </b-button>
       <meta itemprop="position" content="3" />
     </li>

--- a/web/components/player/player-mode-card.vue
+++ b/web/components/player/player-mode-card.vue
@@ -31,7 +31,7 @@
 
       <b-card
         v-if="activeMap != undefined"
-        :title="$t('player.tips-for.map', { map: $t('map.' + activeMap.id) })"
+        :title="$te(`map.${activeMap.id}`) && $t(`map.${activeMap.id}`) || activeMap.map"
         :elevation="0"
         class="mt-2"
         dense

--- a/web/composables/top-n-title.ts
+++ b/web/composables/top-n-title.ts
@@ -19,7 +19,7 @@ export default function useTopNTitle(i18nPrefix: string, sliceRef: Ref<SliceValu
     }
     return i18n.t(i18nPrefix + '.for.map', {
       mode: i18n.t('mode.' + mode) as string,
-      map: id?.value == '0' ? i18n.t('map.Competition Entry') : i18n.t('map.' + id?.value) as string,
+      map: (i18n.te(`map.${id?.value}`) && i18n.t(`map.${id?.value}`) || map) as string,
       ...args?.value,
     }) as string
   })

--- a/web/lang/de.json
+++ b/web/lang/de.json
@@ -142,7 +142,6 @@
     "leaderboard.player.description": "Top {length} Spieler auf Brawl Time Ninja, stündlich aktualisiert.",
     "leaderboard.player.metric.description": "Die besten Brawl Stars-Spieler weiltweit, gerankt nach {metric}.",
     "leaderboard.player.metric.title": "Brawl Stars {metric} Bestenliste",
-    "map": "Map | Maps",
     "map.Competition Entry": "Wettbewerbseintrag",
     "metric.accountRating": "Account-Bewertung",
     "metric.accountRating.description": "Die Bewertung wird berechnet, indem deine mittleren Brawler-Trophäen mit dem Durchschnitt aller Spieler zu Saisonende verglichen werden.",

--- a/web/lang/en.json
+++ b/web/lang/en.json
@@ -156,7 +156,6 @@
     "leaderboard.player.description": "Top {length} players on Brawl Time Ninja, updated hourly",
     "leaderboard.player.metric.description": "The best Brawl Stars players world wide, ranked by {metric}.",
     "leaderboard.player.metric.title": "Brawl Stars {metric} Leaderboard",
-    "map": "Map | Maps",
     "map.Competition Entry": "Competition Entry",
     "metric.accountRating": "Account Rating",
     "metric.accountRating.description": "The rating is calculated by comparing your mean Brawler trophies to all player's mean Brawler trophies at season end.",

--- a/web/lang/es.json
+++ b/web/lang/es.json
@@ -182,7 +182,6 @@
     "leaderboard.player.description": "{length} jugadores con mayor número de horas jugadas, actualizado cada hora.",
     "leaderboard.player.metric.description": "Los mejores jugadores de Brawl Stars en todo el mundo, a nivel de {metric}.",
     "leaderboard.player.metric.title": "Tabla de posiciones de {metric} de Brawl Stars",
-    "map": "Mapa | Mapas",
     "map.Competition Entry": "Candidatos del día",
     "map.insights.compare-to.mode": "Comparado con {mode}",
     "map.insights.description": "Se usa un test estadístico para encontrar valores atípicos en los datos.",

--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -313,7 +313,7 @@ export default defineComponent({
           type: 'application/ld+json',
           json: formatAsJsonLd({
             id: event.id.toString(),
-            map: i18n.t('map.' + event.id) as string,
+            map: (i18n.te(`map.${event.id}`) && i18n.t(`map.${event.id}`) || event.map) as string,
             mode: i18n.t('mode.' + event.mode) as string,
             start: event.start,
             end: event.end,

--- a/web/pages/tier-list/map/index.vue
+++ b/web/pages/tier-list/map/index.vue
@@ -117,7 +117,7 @@ export default defineComponent({
           type: 'application/ld+json',
           json: formatAsJsonLd({
             id: event.id,
-            map: i18n.t('map.' + event.id) as string,
+            map: (i18n.te(`map.${event.id}`) && i18n.t(`map.${event.id}`) || event.map) as string,
             mode: i18n.t('mode.' + event.mode) as string,
             start: event.start,
             end: event.end,

--- a/web/pages/tier-list/mode/_mode/map/_map.vue
+++ b/web/pages/tier-list/mode/_mode/map/_map.vue
@@ -1,7 +1,7 @@
 <template>
   <b-page
     v-if="event != undefined"
-    :title="$t('tier-list.map.title', { map: title })"
+    :title="$t('tier-list.map.title', { map: $te(`map.${event.id}`) && $t(`map.${event.id}`) || event.map })"
   >
     <breadcrumbs
       :links="[{
@@ -12,14 +12,17 @@
         name: $t('mode.' + event.mode),
       }, {
         path: mapPath,
-        name: event.id != '0' ? $t('map.' + event.id) : event.map,
+        name: $te(`map.${event.id}`) && $t(`map.${event.id}`) || event.map,
       }]"
       class="mt-4"
     ></breadcrumbs>
 
     <div>
       <p class="prose dark:prose-invert">
-        {{ $t('tier-list.map.description', { map: title, mode: $t('mode.' + event.mode) }) }}
+        {{ $t('tier-list.map.description', {
+          map: $te(`map.${event.id}`) && $t(`map.${event.id}`) || event.map,
+          mode: $t('mode.' + event.mode)
+        }) }}
       </p>
       <p v-if="event.map.startsWith('Competition ')">
         {{ $t('tier-list.competition-info') }}


### PR DESCRIPTION
Fixes [issue reported here](https://discord.com/channels/601141229312540693/791336249557647420/955909781187596399). On rare occasions, 'lazy' translations (API) may be unreachable (which results in `en.json` failing to load and an incomplete `{ [id]: 'Map Name'}` record). These changes fix the `subtitle` expression passed to the `<b-card>` so that it will default to the actual map name instead of the i18n key, which is never useful to show in the UI.
Additionally, **it is critical that map names always display even if not localized as the site becomes unusable when defaulting to the i18n key name**.