### PR TITLE
Fix: missing & competition events in 'all events' roll

### DIFF
--- a/web/plugins/klicker.ts
+++ b/web/plugins/klicker.ts
@@ -94,17 +94,21 @@ class CustomKlicker extends Klicker {
   }
 
   async queryActiveEvents(metricsIds: string[] = [], slices: SliceValue = {}, maxage: number|null = 60): Promise<EventMetadata[]> {
-    const events = await this.query({
-      cubeId: 'map',
-      dimensionsIds: ['mode', 'map', 'powerplay'],
-      metricsIds: ['eventId', 'timestamp', ...metricsIds],
-      slices: {
-        season: [getCurrentSeasonEnd().toISOString().slice(0, 10)],
-        ...slices,
+    const APPROXIMATE_MODE_COUNT = 15;
+    const events = await this.query(
+      {
+        cubeId: 'map',
+        dimensionsIds: ['mode', 'map', 'powerplay'],
+        metricsIds: ['eventId', 'timestamp', ...metricsIds],
+        slices: {
+          season: [getCurrentSeasonEnd().toISOString().slice(0, 10)],
+          ...slices,
+        },
+        sortId: 'timestamp',
+        limit: APPROXIMATE_MODE_COUNT * 15,
       },
-      sortId: 'timestamp',
-      limit: 20,
-    })
+      ({ dimensions: { map } }) => map.includes('Competition') === false
+    )
 
     const lastEvents = events.data
       .map(e => ({


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1146921/161847796-bc4ff3b9-406a-4bad-a8ee-7f60605f239b.png)

Currently, very few events are shown in the 'all events' roll due mostly to the disproportionate number of events per mode[^2] and a low query $limit (20) and as a result there is no longer an easy or fast way to find a map by name on BrawltimeNinja. To restore this feature, this PR **significantly increases the $limit to allow the query to select _all_ maps**.
Additionally, to offset this change, and because of their limited usefulness, **competition maps are no longer included in the 'all events' query**[^1].

  [^1]: This is a global service method… it may be desired sometimes to view competition entries in other places but I went with the pessimistic option of excluding them. This could be reverted and query instead extended with an additional filter param.
  [^2]:
	As little as 7 maps… at most around 15 maps per mode!
	With like 15 modes queried a $limit of 20 only allows for 0 - 3 maps per mode to be shown