### PR TITLE
Hotfix: brawler description text overflow

### DIFF
--- a/klicker/components/ui/b-kv-table.vue
+++ b/klicker/components/ui/b-kv-table.vue
@@ -11,7 +11,7 @@
       <dt class="text-text/75">
         {{ row.title }}
       </dt>
-      <dd class="flex-shrink-0 whitespace-nowrap overflow-x-auto hide-scrollbar text-text text-right">
+      <dd class="flex-shrink-0 whitespace-nowrap overflow-x-auto hide-scrollbar text-text text-right max-w-[65%]">
         <slot
           :name="row.slot"
           :row="data"


### PR DESCRIPTION
<img width="694" alt="ss 2022-08-15 at 17 54 15@2x" src="https://user-images.githubusercontent.com/1146921/184734398-fa3df80c-c684-4582-a1f3-5e30d6de75f4.png">

<img width="694" alt="ss 2022-08-15 at 17 55 28@2x" src="https://user-images.githubusercontent.com/1146921/184734432-cda0e78d-267b-4604-bcca-047fc99624d1.png">

<sup>(Untested; could not start dev environment)</sup>