### PR TITLE
Change: <STrophies> range default: 0-15 →  5-10

### DIFF
--- a/web/components/klicker/s-trophies.vue
+++ b/web/components/klicker/s-trophies.vue
@@ -24,8 +24,8 @@ export default defineComponent({
     const model = computed({
       get() {
         return {
-          gte: parseInt(props.value.trophyRangeGte?.[0] as string) || undefined,
-          lt: parseInt(props.value.trophyRangeLt?.[0] as string) || undefined,
+          gte: parseInt(props.value.trophyRangeGte?.[0] as string) || 5,
+          lt: parseInt(props.value.trophyRangeLt?.[0] as string) || 10,
         }
       },
       set(v: { gte?: number, lt?: number }) {


### PR DESCRIPTION
<sup>PR serves as a RFC/proposal</sup>

Currently, BrawlTimeNinja does not apply any default filtering by trophies. This poses a problem for the average user as the unfiltered data, while adding to the "completeness" of the data set, includes outliers that _dramatically_ skew the `win` and `usage` rates of the dashboard– both from lower-tier games where new brawlers often dominate _and_ 99th percentile games which often are both entirely pre-made teams where specific brawlers e.g., Ruff, shine (seen clearly in "Best Teams" frequency graph) and are almost always are matched poorly with a comical disparity in rank[^1].

I propose that the `<STrophies>` slicer component **should use a sensible default in order to provide _meaningful_ stats to the majority/average user**. I chose 500-1000 as this _should_ comprise the bell-curve of most players but I am not unbiased and this may not be the case.

[^1]: although this is admittedly much less of an issue at a certain point and an alternate default range could be `{ gte: 5, lte: undefined}` but this would still favor brawlers that excel in pre-made teams 